### PR TITLE
fix(node-utils): wait for upgrade-info.json to be written to disk

### DIFF
--- a/pkg/nodeutils/node.go
+++ b/pkg/nodeutils/node.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync/atomic"
+	"time"
 
 	"github.com/gorilla/mux"
 	log "github.com/sirupsen/logrus"
@@ -76,6 +77,10 @@ func (s *NodeUtils) Start() error {
 				if s.upgradeChecker.ShouldUpgrade(s.latestBlockHeight.Load()) {
 					log.WithField("height", s.latestBlockHeight.Load()).Warn("stopping tracer to force application stop for upgrade")
 					s.requiresUpgrade = true
+
+					// wait for upgrade-info.json to be written to disk
+					time.Sleep(5 * time.Second)
+
 					err := s.StopNode()
 					if err != nil {
 						log.Errorf("failed to stop tracer: %v", err)


### PR DESCRIPTION
When the network reaches the upgrade height, nodes write the `upgrade-info.json` to disk and then panics. Closing the trace.fifo file too fast sometimes causes the write to not flush to disk, leaving the node in a semi-upgradeable state.

Let's wait a few seconds for the `upgrade-info.json` to be written to disk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a 5-second delay before stopping the node if an upgrade is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->