### PR TITLE
fix(chainnode): ensure pod restart when number of containers changes

### DIFF
--- a/examples/chainnodeset/nibid_with_firewall.yaml
+++ b/examples/chainnodeset/nibid_with_firewall.yaml
@@ -1,0 +1,135 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nibiru-testnet-firewall
+immutable: false
+data:
+  firewall.yml: |
+    cache:
+      ttl: 5s
+
+    lcd:
+      default: deny
+
+      rules:
+        - priority: 1000
+          action: allow
+          paths:
+            - /cosmos/base/tendermint/v1beta1/node_info
+          methods:
+            - GET
+          cache:
+            enable: true
+            ttl: 30s
+
+    grpc:
+      default: deny
+
+      rules:
+        - action: allow
+          methods:
+            - /cosmos.bank.v1beta1.Query/AllBalances
+            - /cosmos.base.node.v1beta1.Service/Config
+            - /ibc.core.client.v1.Query/ClientStates
+            - /cosmos.base.tendermint.v1beta1.Service/GetNodeInfo
+            - /ibc.core.connection.v1.Query/ClientConnections
+
+    rpc:
+      default: deny
+
+      rules:
+        - priority: 1000
+          action: allow
+          paths:
+            - /genesis
+          methods:
+            - GET
+          cache:
+            enable: true
+            ttl: 1m
+
+      jsonrpc:
+        default: deny
+
+        webSocketEnabled: true
+
+        rules:
+          - priority: 1000
+            action: allow
+            methods: [ "subscribe", "unsubscribe", "unsubscribe_all", "broadcast_tx_sync", "tx_search", "commit" ]
+
+          - priority: 1000
+            action: allow
+            methods: [ "block_results", "abci_info" ]
+            cache:
+              enable: true
+              ttl: 15s
+---
+apiVersion: apps.k8s.nibiru.org/v1
+kind: ChainNodeSet
+metadata:
+  name: nibiru-testnet
+spec:
+  app:
+    image: ghcr.io/nibiruchain/nibiru
+    version: 1.1.0
+    app: nibid
+
+  validator:
+    info:
+      moniker: nibiru
+      website: https://nibiru.fi
+    config:
+      reconcilePeriod: 10m
+      override:
+        app.toml:
+          minimum-gas-prices: 0.025unibi
+      sidecars:
+        - name: pricefeeder
+          image: ghcr.io/nibiruchain/pricefeeder:1.0.0
+          env:
+            - name: FEEDER_MNEMONIC
+              valueFrom:
+                secretKeyRef:
+                  name: nibiru-testnet-validator-account
+                  key: mnemonic
+            - name: CHAIN_ID
+              value: nibiru-devnet-0
+            - name: GRPC_ENDPOINT
+              value: localhost:9090
+            - name: WEBSOCKET_ENDPOINT
+              value: ws://localhost:26657/websocket
+            - name: EXCHANGE_SYMBOLS_MAP
+              value: '{"bitfinex":{"ubtc:unusd":"tBTCUSD","ueth:unusd":"tETHUSD","uusdc:unusd":"tUDCUSD"},"binance":{"ubtc:uusd":"BTCUSD","ueth:uusd":"ETHUSD","uusdt:uusd":"USDTUSD","uusdc:uusd":"USDCUSD","uatom:uusd":"ATOMUSD","ubnb:uusd":"BNBUSD","uavax:uusd":"AVAXUSD","usol:uusd":"SOLUSD","uada:uusd":"ADAUSD","ubtc:unusd":"BTCUSD","ueth:unusd":"ETHUSD","uusdt:unusd":"USDTUSD","uusdc:unusd":"USDCUSD","uatom:unusd":"ATOMUSD","ubnb:unusd":"BNBUSD","uavax:unusd":"AVAXUSD","usol:unusd":"SOLUSD","uada:unusd":"ADAUSD"}}'
+
+    init:
+      chainID: nibiru-devnet-0
+      assets: [ "100000000000000unibi", "1000000000000000000unusd", "10000000000000000uusdt" ]
+      stakeAmount: 100000000unibi
+      unbondingTime: 120s
+      votingPeriod: 120s
+      additionalInitCommands:
+        - command: [ "sh", "-c" ]
+          args:
+            - >
+              nibid genesis add-sudo-root-account \
+                $(nibid keys show account -a --home=/home/app --keyring-backend test) \
+                --home=/home/app
+
+  nodes:
+    - name: fullnodes
+      instances: 1
+
+      config:
+        reconcilePeriod: 10m
+        firewall:
+          enable: true
+          config:
+            name: nibiru-testnet-firewall
+            key: firewall.yml
+        override:
+          app.toml:
+            minimum-gas-prices: 0.025unibi
+            pruning: custom
+            pruning-keep-recent: "100"
+            pruning-interval: "10"

--- a/internal/controllers/chainnode/pod.go
+++ b/internal/controllers/chainnode/pod.go
@@ -735,6 +735,10 @@ func podSpecChanged(existing, new *corev1.Pod) bool {
 	orderVolumeMounts(existingCopy)
 	orderVolumeMounts(newCopy)
 
+	if len(existingCopy.Spec.Containers) != len(new.Spec.Containers) {
+		return true
+	}
+
 	patchResult, err := patch.DefaultPatchMaker.Calculate(existingCopy, newCopy,
 		patch.IgnoreStatusFields(),
 		patch.IgnoreVolumeClaimTemplateTypeMetaAndStatus(),


### PR DESCRIPTION
Closes #127.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Improved condition checking in the `podSpecChanged` function to handle cases where the number of containers in existing and new pods is different.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->