### PR TITLE
feat: use correct app version when restoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ docs: crd-to-markdown
 ##@ Development
 
 .PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: generate controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	@$(CONTROLLER_GEN) \
 		rbac:roleName=manager-role crd webhook paths="./..." \
 		output:crd:artifacts:config=helm/nibiru-operator/crds \

--- a/api/v1/chainnode_helper.go
+++ b/api/v1/chainnode_helper.go
@@ -208,8 +208,28 @@ func (chainNode *ChainNode) GetAppVersion() string {
 	return version
 }
 
+func (chainNode *ChainNode) GetLatestVersion() string {
+	version := chainNode.Spec.App.GetImageVersion()
+	var h int64 = 0
+	for _, u := range chainNode.Status.Upgrades {
+		if (u.Status == UpgradeCompleted || u.Status == UpgradeSkipped) && u.Height > h {
+			h = u.Height
+			version = u.GetVersion()
+		}
+	}
+	return version
+}
+
+func (chainNode *ChainNode) GetAppImageWithVersion(version string) string {
+	return fmt.Sprintf("%s:%s", chainNode.Spec.App.Image, version)
+}
+
 func (chainNode *ChainNode) GetAppImage() string {
-	return fmt.Sprintf("%s:%s", chainNode.Spec.App.Image, chainNode.GetAppVersion())
+	return chainNode.GetAppImageWithVersion(chainNode.GetAppVersion())
+}
+
+func (chainNode *ChainNode) GetLatestAppImage() string {
+	return chainNode.GetAppImageWithVersion(chainNode.GetLatestVersion())
 }
 
 // Validator methods

--- a/examples/chainnodeset/nibiru_mainnet.yaml
+++ b/examples/chainnodeset/nibiru_mainnet.yaml
@@ -17,16 +17,6 @@ spec:
 
       stateSyncRestore: true
 
-      ingress:
-        host: nibiru.voluzi.internal
-        enableGRPC: true
-        enableLCD: true
-        enableRPC: true
-        disableTLS: true
-        annotations:
-          nginx.ingress.kubernetes.io/cors-allow-origin: '*'
-          nginx.ingress.kubernetes.io/enable-cors: "true"
-
       expose:
         p2p: true
         p2pServiceType: LoadBalancer

--- a/internal/controllers/chainnode/constant.go
+++ b/internal/controllers/chainnode/constant.go
@@ -24,6 +24,8 @@ const (
 	AnnotationStateSyncTrustHeight = "apps.k8s.nibiru.org/state-sync-trust-height"
 	AnnotationStateSyncTrustHash   = "apps.k8s.nibiru.org/state-sync-trust-hash"
 
+	annotationDataHeight = "apps.k8s.nibiru.org/data-height"
+
 	annotationSafeEvict               = "cluster-autoscaler.kubernetes.io/safe-to-evict"
 	annotationConfigHash              = "apps.k8s.nibiru.org/config-hash"
 	annotationDataInitialized         = "apps.k8s.nibiru.org/data-initialized"

--- a/internal/controllers/chainnode/controller.go
+++ b/internal/controllers/chainnode/controller.go
@@ -255,6 +255,12 @@ func (r *Reconciler) updateLatestHeight(ctx context.Context, chainNode *appsv1.C
 	if height == 0 {
 		return nil
 	}
+
+	// Avoid API call if there is nothing to change
+	if height == chainNode.Status.LatestHeight {
+		return nil
+	}
+
 	chainNode.Status.LatestHeight = height
 	return r.Status().Update(ctx, chainNode)
 }

--- a/internal/controllers/chainnode/pod.go
+++ b/internal/controllers/chainnode/pod.go
@@ -460,6 +460,11 @@ func (r *Reconciler) getPodSpec(ctx context.Context, chainNode *appsv1.ChainNode
 		},
 	}
 
+	// Always use latest version we know if we are doing state-sync restore
+	if chainNode.StateSyncRestoreEnabled() && chainNode.Status.LatestHeight == 0 {
+		pod.Spec.Containers[0].Image = chainNode.GetLatestAppImage()
+	}
+
 	if !chainNode.Spec.Genesis.ShouldUseDataVolume() {
 		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
 			Name: "genesis",

--- a/internal/controllers/chainnode/snapshots.go
+++ b/internal/controllers/chainnode/snapshots.go
@@ -329,7 +329,9 @@ func (r *Reconciler) createSnapshot(ctx context.Context, chainNode *appsv1.Chain
 			}
 		}
 	}
-
+	if err := r.updateLatestHeight(ctx, chainNode); err != nil {
+		return nil, err
+	}
 	snapshot := getVolumeSnapshotSpec(chainNode)
 	return snapshot, r.Create(ctx, snapshot)
 }
@@ -371,6 +373,7 @@ func getVolumeSnapshotSpec(chainNode *appsv1.ChainNode) *snapshotv1.VolumeSnapsh
 			Namespace: chainNode.GetNamespace(),
 			Annotations: map[string]string{
 				annotationPvcSnapshotReady: strconv.FormatBool(false),
+				annotationDataHeight:       strconv.FormatInt(chainNode.Status.LatestHeight, 10),
 			},
 			Labels: WithChainNodeLabels(chainNode, map[string]string{
 				LabelChainNode: chainNode.GetName(),


### PR DESCRIPTION
When there are upgrades (either inherited from `ChainNodeSet` or simply past upgrades of the `ChainNode`), operator decides which version to use based on the `.status.LatestHeight`, to make sure that when syncing from scratch the node will sync with the correct version for each height interval. However, there are some situations in which the operator does not know the block height of the data, hence not knowing which version to use either. Those situations are:
* When `ChainNode` is created/recreated and is using an existing volume: in this case the volume can contain data that was already upgraded. If the `ChainNode` belongs to a `ChainNodeSet`, its `.status.upgrades` will be already populated with the upgrades history. So, if the operator knows which block height is on the volume data, he will be able to use the right app version.
* When `ChainNode` is set to create its volume from a PVC snapshot: the PVC restored from a snapshot will have no information on which block height the data is.
* When restoring using state-sync: in this case we always want to use the latest version used on upgrades. 

This PR addresses those 3 situations:
- [x] Periodically store latest height on PVC annotations, and load it when re-using an existing volume;
- [x] Store latest height on Volume Snapshot annotations, and load it when restoring from a Volume Snapshot;
- [x] Always use latest known version when restoring from state-sync. 


Closes #129 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added methods for version information retrieval and image construction in the `ChainNode` struct.
	- Introduced functionality to handle height updates from snapshots during node operations.
	- Updated `Makefile` to include a command for generating objects.

- **Bug Fixes**
	- Implemented a check to avoid unnecessary API calls in the `updateLatestHeight` function.
	- Conditionally updated container image in `getPodSpec` based on state-sync restore criteria.

- **Refactor**
	- Added a new constant for annotation data height.
	- Modified the `createSnapshot` function for improved error handling and setting annotation data height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->