### PR TITLE
feat(chainnode): nodeutils as native sidecar & config refresh on upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Kubernetes controllers to manage nibiru (and other cosmos nodes) on a Kubernetes
 ## Description
 // TODO(user): An in-depth paragraph about your project and overview of use
 
+## Requirements
+* Kubernetes cluster v1.29
+
 ## Getting Started
 You’ll need a Kubernetes cluster to run against. You can use [KIND](https://sigs.k8s.io/kind) to get a local cluster for testing, or run against a remote cluster.
 **Note:** Your controller will automatically use the current context in your kubeconfig file (i.e. whatever cluster `kubectl cluster-info` shows).

--- a/api/v1/chainnode_helper.go
+++ b/api/v1/chainnode_helper.go
@@ -200,7 +200,7 @@ func (chainNode *ChainNode) GetAppVersion() string {
 	version := chainNode.Spec.App.GetImageVersion()
 	var h int64 = 0
 	for _, u := range chainNode.Status.Upgrades {
-		if (u.Status == UpgradeCompleted || u.Status == UpgradeSkipped) && u.Height > h && u.Height <= chainNode.Status.LatestHeight {
+		if (u.Status == UpgradeCompleted || u.Status == UpgradeSkipped || u.Status == UpgradeOnGoing) && u.Height > h && u.Height <= chainNode.Status.LatestHeight {
 			h = u.Height
 			version = u.GetVersion()
 		}

--- a/internal/controllers/chainnode/controller.go
+++ b/internal/controllers/chainnode/controller.go
@@ -190,7 +190,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// Ensure pod is running
-	if err := r.ensurePod(ctx, chainNode, configHash); err != nil {
+	if err := r.ensurePod(ctx, app, chainNode, configHash); err != nil {
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
Closes #140 .
Closes #143.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `APP_VERSION` variable assignment and usage in the deploy process.
	- Updated Helm commands to use `APP_VERSION` and `--app-version`.
	- Added project requirements section in README specifying Kubernetes cluster v1.29.

- **Bug Fixes**
	- Improved version update logic in `GetAppVersion` method of `ChainNode`.
	- Enhanced pod management logic in `Reconcile` method of `Reconciler`.

- **Refactor**
	- Modified `ensurePod` function signature to include `app *chainutils.App`.
	- Updated pod spec, config files, and container settings for pod upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->