### PR TITLE
chore(chainnodeset): use int instead of string on status publicPort

### DIFF
--- a/api/v1/chainnodeset_types.go
+++ b/api/v1/chainnodeset_types.go
@@ -145,7 +145,7 @@ type ChainNodeSetNodeStatus struct {
 
 	// Port to reach this node publicly.
 	// +optional
-	PublicPort string `json:"publicPort,omitempty"`
+	PublicPort int `json:"publicPort,omitempty"`
 
 	// P2P port for connecting to this node.
 	Port int `json:"port"`

--- a/docs/api/02-chainnodeset.md
+++ b/docs/api/02-chainnodeset.md
@@ -76,7 +76,7 @@ ChainNodeSetNodeStatus contains information about a node running on this ChainNo
 | id | ID of this node. | string | true |
 | address | Hostname or IP address to reach this node internally. | string | true |
 | publicAddress | Hostname or IP address to reach this node publicly. | string | false |
-| publicPort | Port to reach this node publicly. | string | false |
+| publicPort | Port to reach this node publicly. | int | false |
 | port | P2P port for connecting to this node. | int | true |
 | group | Group to which this ChainNode belongs. | string | false |
 

--- a/helm/nibiru-operator/crds/apps.k8s.nibiru.org_chainnodesets.yaml
+++ b/helm/nibiru-operator/crds/apps.k8s.nibiru.org_chainnodesets.yaml
@@ -4769,7 +4769,7 @@ spec:
                       type: string
                     publicPort:
                       description: Port to reach this node publicly.
-                      type: string
+                      type: integer
                     seed:
                       description: Indicates if this node is running in seed mode.
                       type: boolean

--- a/internal/controllers/chainnodeset/nodes.go
+++ b/internal/controllers/chainnodeset/nodes.go
@@ -140,7 +140,10 @@ func (r *Reconciler) ensureNodeGroup(ctx context.Context, nodeSet *appsv1.ChainN
 		}
 		if node.Status.PublicAddress != "" {
 			if parts := strings.Split(node.Status.PublicAddress, ":"); len(parts) == 2 {
-				publicPort := parts[1]
+				publicPort, err := strconv.Atoi(parts[1])
+				if err != nil {
+					return err
+				}
 				if parts = strings.Split(parts[0], "@"); len(parts) == 2 {
 					nodeStatus.Public = true
 					nodeStatus.PublicPort = publicPort


### PR DESCRIPTION
Closes #168 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved consistency in the `publicPort` data type by changing it from `string` to `int` across the application.
  
- **Documentation**
  - Updated API documentation to reflect the `publicPort` field type change from `string` to `int`.

- **Bug Fixes**
  - Added error handling for `publicPort` conversion to ensure robust type checking and prevent potential runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->