### PR TITLE
feat(chainnode): add disruption check on pod replacements

### DIFF
--- a/cmd/manager/config.go
+++ b/cmd/manager/config.go
@@ -68,4 +68,14 @@ func init() {
 		environ.GetString("RELEASE_NAME", "cosmopilot"),
 		"the release-name passed in helm (used to get PriorityClass names to assign to pods)",
 	)
+
+	flag.BoolVar(&runOpts.DisruptionCheckEnabled, "disruption-checks-enabled",
+		environ.GetBool("DISRUPTION_CHECKS_ENABLED", true),
+		"whether to enable pod disruption checks.",
+	)
+
+	flag.IntVar(&runOpts.DisruptionMaxUnavailable, "disruption-max-unavailable",
+		environ.GetInt("DISRUPTION_MAX_UNAVAILABLE", 1),
+		"maximum number of unavailable pods with same labels.",
+	)
 }

--- a/helm/cosmopilot/templates/deployment.yaml
+++ b/helm/cosmopilot/templates/deployment.yaml
@@ -67,6 +67,8 @@ spec:
               value: "{{ .Values.debugMode }}"
             - name: ENABLE_LEADER_ELECTION
               value: "true"
+            - name: DISRUPTION_CHECKS_ENABLED
+              value:  "{{ .Values.disruptionChecksEnabled }}"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/helm/cosmopilot/values.yaml
+++ b/helm/cosmopilot/values.yaml
@@ -10,6 +10,7 @@ webHooksEnabled: true
 nodeSelector: {}
 debugMode: false
 probesEnabled: true
+disruptionChecksEnabled: true
 
 nodesPodPriority: 950
 validatorPodPriority: 1050

--- a/internal/controllers/chainnode/disruption.go
+++ b/internal/controllers/chainnode/disruption.go
@@ -1,0 +1,120 @@
+package chainnode
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var (
+	locks      = make(map[string]*sync.Mutex)
+	locksMutex sync.Mutex
+)
+
+func generateLockKey(l map[string]string) string {
+	var keys []string
+	for k := range l {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // Sort the keys to ensure deterministic order
+
+	var builder strings.Builder
+	for _, k := range keys {
+		builder.WriteString(fmt.Sprintf("%s=%s,", k, l[k]))
+	}
+	return builder.String()
+}
+
+func getLockForLabels(l map[string]string) *sync.Mutex {
+	lockKey := generateLockKey(l)
+
+	locksMutex.Lock()
+	defer locksMutex.Unlock()
+
+	if lock, exists := locks[lockKey]; exists {
+		return lock
+	}
+
+	newLock := &sync.Mutex{}
+	locks[lockKey] = newLock
+	return newLock
+}
+
+func (r *Reconciler) checkDisruptionAllowance(ctx context.Context, l map[string]string) error {
+	logger := log.FromContext(ctx)
+
+	podsList, err := r.listPodsWithLabels(ctx, l)
+	if err != nil {
+		return err
+	}
+	unavailable := unavailablePodCount(podsList)
+
+	logger.V(1).Info("disruption check", "unavailable", unavailable, "labels", l)
+	if unavailable >= r.opts.DisruptionMaxUnavailable {
+		return fmt.Errorf("%d pods are unavailable", unavailable)
+	}
+	return nil
+}
+
+func (r *Reconciler) listPodsWithLabels(ctx context.Context, l map[string]string) (*corev1.PodList, error) {
+	podList := &corev1.PodList{}
+	return podList, r.List(ctx, podList, &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(l),
+	})
+}
+
+func unavailablePodCount(podList *corev1.PodList) int {
+	unavailable := 0
+	for _, pod := range podList.Items {
+		if !isPodRunningAndReady(&pod) {
+			unavailable++
+		}
+	}
+
+	return unavailable
+}
+
+func isPodRunningAndReady(pod *corev1.Pod) bool {
+	// Check if the pod's phase is "Running"
+	if pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+
+	// Check the pod's "Ready" condition is "True"
+	ready := false
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+			ready = true
+			break
+		}
+	}
+
+	if !ready {
+		return false
+	}
+
+	// Check if all containers are ready
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if !containerStatus.Ready || containerStatus.State.Running == nil {
+			return false
+		}
+	}
+
+	// Check if node-utils and cosmoguard containers are ready
+	for _, containerStatus := range pod.Status.InitContainerStatuses {
+		if containerStatus.Name == nodeUtilsContainerName || containerStatus.Name == cosmoGuardContainerName {
+			if !containerStatus.Ready || containerStatus.State.Running == nil {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/internal/controllers/options.go
+++ b/internal/controllers/options.go
@@ -7,12 +7,14 @@ const (
 )
 
 type ControllerRunOptions struct {
-	WorkerCount     int
-	WorkerName      string
-	NodeUtilsImage  string
-	DisableWebhooks bool
-	CosmoGuardImage string
-	ReleaseName     string
+	WorkerCount              int
+	WorkerName               string
+	NodeUtilsImage           string
+	DisableWebhooks          bool
+	CosmoGuardImage          string
+	ReleaseName              string
+	DisruptionCheckEnabled   bool
+	DisruptionMaxUnavailable int
 }
 
 func (opts *ControllerRunOptions) GetDefaultPriorityClassName() string {


### PR DESCRIPTION
Closes #203 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new command-line flags for enhanced pod disruption management, including options to enable disruption checks and set maximum unavailable pods.
	- Added a new environment variable for managing disruption checks within Kubernetes deployments.
	- Enabled configuration for disruption checks in the application settings.
	- Implemented functionality for managing pod disruption checks, ensuring operations respect defined limits on pod availability.

- **Bug Fixes**
	- Improved logic for pod recreation to adhere to disruption policies, ensuring smoother operations during pod failures.

- **Documentation**
	- Updated configuration options in the Helm values file to reflect new disruption management features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->