### PR TITLE
feat(chainnode): handle pod waiting status when failing to pull image

### DIFF
--- a/internal/controllers/chainnode/constant.go
+++ b/internal/controllers/chainnode/constant.go
@@ -70,6 +70,9 @@ const (
 
 	VolumeSnapshotDataSourceKind     = "VolumeSnapshot"
 	VolumeSnapshotDataSourceApiGroup = "snapshot.storage.k8s.io"
+
+	ReasonImagePullBackOff = "ImagePullBackOff"
+	ReasonErrImagePull     = "ErrImagePull"
 )
 
 var (

--- a/internal/controllers/chainnode/pod.go
+++ b/internal/controllers/chainnode/pod.go
@@ -1070,6 +1070,9 @@ func podInFailedState(chainNode *appsv1.ChainNode, pod *corev1.Pod) bool {
 		if !c.Ready && c.State.Terminated != nil {
 			return true
 		}
+		if isImagePullFailure(c.State.Waiting) {
+			return true
+		}
 	}
 
 	for _, c := range pod.Status.InitContainerStatuses {
@@ -1087,8 +1090,15 @@ func podInFailedState(chainNode *appsv1.ChainNode, pod *corev1.Pod) bool {
 				}
 			}
 		}
+		if isImagePullFailure(c.State.Waiting) {
+			return true
+		}
 	}
 	return false
+}
+
+func isImagePullFailure(state *corev1.ContainerStateWaiting) bool {
+	return state != nil && (state.Reason == ReasonImagePullBackOff || state.Reason == ReasonErrImagePull)
 }
 
 func nodeUtilsIsInFailedState(pod *corev1.Pod) bool {


### PR DESCRIPTION
Closes #205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new error constants for improved handling of container image pulling failures.

- **Bug Fixes**
	- Enhanced error detection for pod management, allowing better identification of failed states related to image pull issues.

- **Improvements**
	- Updated logging for clearer insights into pod status during operations.
	- Improved robustness of pod failure detection with additional checks for image pull failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->