### PR TITLE
chore(chainnode): only apply state-sync configs if node is not running

### DIFF
--- a/internal/controllers/chainnode/configmap.go
+++ b/internal/controllers/chainnode/configmap.go
@@ -42,7 +42,7 @@ func getConfigsLockForAppVersion(version string) *sync.Mutex {
 	return newLock
 }
 
-func (r *Reconciler) ensureConfigMap(ctx context.Context, app *chainutils.App, chainNode *appsv1.ChainNode) (string, error) {
+func (r *Reconciler) ensureConfigMap(ctx context.Context, app *chainutils.App, chainNode *appsv1.ChainNode, nodePodRunning bool) (string, error) {
 	logger := log.FromContext(ctx)
 
 	configs, err := r.getGeneratedConfigs(ctx, app, chainNode)
@@ -151,8 +151,8 @@ func (r *Reconciler) ensureConfigMap(ctx context.Context, app *chainutils.App, c
 		return "", err
 	}
 
-	// Apply state-sync restore config if enabled and node hasn't started yet
-	if chainNode.StateSyncRestoreEnabled() && chainNode.Status.LatestHeight == 0 {
+	// Apply state-sync restore config if enabled and node is not running
+	if chainNode.StateSyncRestoreEnabled() && !nodePodRunning {
 		peers, stateSyncAnnotations, err := r.getChainPeers(ctx, chainNode, AnnotationStateSyncTrustHeight, AnnotationStateSyncTrustHash)
 		if err != nil {
 			return "", err

--- a/internal/controllers/chainnode/controller.go
+++ b/internal/controllers/chainnode/controller.go
@@ -198,7 +198,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// Create/update configmap with config files
 	logger.V(1).Info("ensure config")
-	configHash, err := r.ensureConfigMap(ctx, app, chainNode)
+	configHash, err := r.ensureConfigMap(ctx, app, chainNode, nodePodRunning)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controllers/chainnode/pod.go
+++ b/internal/controllers/chainnode/pod.go
@@ -144,7 +144,7 @@ func (r *Reconciler) ensurePod(ctx context.Context, app *chainutils.App, chainNo
 		if err != nil {
 			return err
 		}
-		configHash, err = r.ensureConfigMap(ctx, app, chainNode)
+		configHash, err = r.ensureConfigMap(ctx, app, chainNode, true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Closes #199.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration management by considering the running status of the node pod, improving the handling of state-sync restoration and upgrades.
	- Improved logging for pod recreation and configuration changes, providing clearer insights into the reconciler's actions.

- **Bug Fixes**
	- Resolved potential issues in configuration application by refining the conditions under which configurations are enforced or validated.

- **Documentation**
	- Added comments to clarify new logic regarding state-sync restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->