### PR TITLE
feat(chainnode): filter non-ready peers from statesync rpc-servers

### DIFF
--- a/internal/controllers/chainnode/configmap.go
+++ b/internal/controllers/chainnode/configmap.go
@@ -158,6 +158,11 @@ func (r *Reconciler) ensureConfigMap(ctx context.Context, app *chainutils.App, c
 			return "", err
 		}
 
+		peers, err = r.filterNonReadyPeers(ctx, chainNode, peers)
+		if err != nil {
+			return "", err
+		}
+
 		rpcServers := make([]string, 0)
 
 		switch {

--- a/internal/controllers/chainnode/controller.go
+++ b/internal/controllers/chainnode/controller.go
@@ -264,16 +264,20 @@ func (r *Reconciler) setupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *Reconciler) getClient(chainNode *appsv1.ChainNode) (*chainutils.Client, error) {
-	data := r.nodeClients.Get(chainNode.GetNodeFQDN())
+func (r *Reconciler) getChainNodeClient(chainNode *appsv1.ChainNode) (*chainutils.Client, error) {
+	return r.getChainNodeClientByHost(chainNode.GetNodeFQDN())
+}
+
+func (r *Reconciler) getChainNodeClientByHost(host string) (*chainutils.Client, error) {
+	data := r.nodeClients.Get(host)
 	if data != nil {
 		return data.Value(), nil
 	}
-	c, err := chainutils.NewClient(chainNode.GetNodeFQDN())
+	c, err := chainutils.NewClient(host)
 	if err != nil {
 		return nil, err
 	}
-	r.nodeClients.Set(chainNode.GetNodeFQDN(), c, ttlcache.DefaultTTL)
+	r.nodeClients.Set(host, c, ttlcache.DefaultTTL)
 	return c, nil
 }
 

--- a/internal/controllers/chainnode/pod.go
+++ b/internal/controllers/chainnode/pod.go
@@ -1025,7 +1025,7 @@ func (r *Reconciler) setNodePhase(ctx context.Context, chainNode *appsv1.ChainNo
 		}
 	}
 
-	c, err := r.getClient(chainNode)
+	c, err := r.getChainNodeClient(chainNode)
 	if err != nil {
 		return err
 	}

--- a/internal/controllers/chainnode/service.go
+++ b/internal/controllers/chainnode/service.go
@@ -358,7 +358,7 @@ func (r *Reconciler) getP2pServiceSpec(chainNode *appsv1.ChainNode) (*corev1.Ser
 func (r *Reconciler) maybeAddStateSyncAnnotations(ctx context.Context, chainNode *appsv1.ChainNode, svc *corev1.Service) error {
 	if chainNode.Spec.Config != nil && chainNode.Spec.Config.StateSync.Enabled() &&
 		chainNode.Status.LatestHeight > int64(chainNode.Spec.Config.StateSync.SnapshotInterval*3) {
-		c, err := r.getClient(chainNode)
+		c, err := r.getChainNodeClient(chainNode)
 		if err != nil {
 			return err
 		}

--- a/internal/controllers/chainnode/upgrades.go
+++ b/internal/controllers/chainnode/upgrades.go
@@ -152,7 +152,7 @@ func (r *Reconciler) setUpgradeStatus(ctx context.Context, chainNode *appsv1.Cha
 }
 
 func (r *Reconciler) getGovUpgrades(ctx context.Context, chainNode *appsv1.ChainNode) ([]appsv1.Upgrade, error) {
-	c, err := r.getClient(chainNode)
+	c, err := r.getChainNodeClient(chainNode)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controllers/chainnode/utils.go
+++ b/internal/controllers/chainnode/utils.go
@@ -1,6 +1,11 @@
 package chainnode
 
 import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	appsv1 "github.com/NibiruChain/cosmopilot/api/v1"
 	"github.com/NibiruChain/cosmopilot/internal/controllers"
 	"github.com/NibiruChain/cosmopilot/internal/utils"
@@ -12,4 +17,25 @@ func WithChainNodeLabels(chainNode *appsv1.ChainNode, additional ...map[string]s
 		labels = utils.MergeMaps(labels, m, controllers.LabelWorkerName)
 	}
 	return labels
+}
+
+func (r *Reconciler) filterNonReadyPeers(ctx context.Context, chainNode *appsv1.ChainNode, peers []appsv1.Peer) ([]appsv1.Peer, error) {
+	logger := log.FromContext(ctx)
+	workingPeers := make([]appsv1.Peer, 0)
+
+	for _, peer := range peers {
+		client, err := r.getChainNodeClientByHost(fmt.Sprintf("%s.%s.svc.cluster.local", peer.Address, chainNode.GetNamespace()))
+		if err != nil {
+			logger.Info("excluding peer from rpc-servers list", "peer", peer.ID, "address", peer.Address)
+			continue
+		}
+		_, err = client.GetNodeStatus(ctx)
+		if err != nil {
+			logger.Info("excluding peer from rpc-servers list", "peer", peer.ID, "address", peer.Address)
+			continue
+		}
+		workingPeers = append(workingPeers, peer)
+	}
+
+	return workingPeers, nil
 }

--- a/internal/controllers/chainnode/validator.go
+++ b/internal/controllers/chainnode/validator.go
@@ -80,7 +80,7 @@ func (r *Reconciler) createValidator(ctx context.Context, app *chainutils.App, c
 func (r *Reconciler) updateJailedStatus(ctx context.Context, chainNode *appsv1.ChainNode) error {
 	logger := log.FromContext(ctx)
 
-	client, err := r.getClient(chainNode)
+	client, err := r.getChainNodeClient(chainNode)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #214 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to filter non-ready peers, enhancing state synchronization reliability.
	- Added improved lifecycle management for chain node pods, including state checks and lifecycle updates.

- **Bug Fixes**
	- Enhanced error handling for client retrieval and pod state checks, ensuring more robust operations.

- **Refactor**
	- Renamed and restructured client retrieval methods for clarity and maintainability.
	- Updated logging for better insights during operations.

- **Documentation**
	- Improved clarity in logging messages related to upgrades and pod management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->